### PR TITLE
remove dependency on wrong package

### DIFF
--- a/Modules/AccountManagement/src/Game.AccountManagement.Api/Game.AccountManagement.Api.csproj
+++ b/Modules/AccountManagement/src/Game.AccountManagement.Api/Game.AccountManagement.Api.csproj
@@ -6,8 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.9" />
+  <ItemGroup>    
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
   </ItemGroup>
 


### PR DESCRIPTION
AccountManagement miał niepotrzebną zależność od Microsoft.AspNet.WebApi.Core, która powodowała warningi (bo to jest paczka dla .NET Framework, nie .NET 7).