### PR TITLE
chore: ignore .DS_Store from commits on macOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# DS_Store
+**/.DS_Store


### PR DESCRIPTION
it's an internal Finder file that's generated when you navigate to a folder.

it's pretty annoying to keep excluding from commits manually