### PR TITLE
feat: include base compose file in llama compose file

### DIFF
--- a/docker-compose-llamacpp.yml
+++ b/docker-compose-llamacpp.yml
@@ -1,5 +1,7 @@
-
 version: '3'
+
+include:
+  - docker-compose.yml
 
 services:
   llama_cpp:


### PR DESCRIPTION
So running the `docker compose -f docker-compose-llamacpp.yml` will run both llama.cpp server and Redis/Postgres as usual.